### PR TITLE
Request module to use new naming structure

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -15,10 +15,12 @@
  */
 var event = require('./event'),
     message = require('./message'),
+    exception = require('./exception'),
     _self;
 
 _self = {
     init: function (url) {
+        var mine = false;
         return {
             url: url,
             allow: function () {
@@ -39,23 +41,29 @@ _self = {
                     }
                 });
             },
-            continue: function () {
+            substitute: function () {
+                mine = true;
                 message.send("ResourceRequestedResponse", {
                     url: url,
                     response: {
                         code: 100,
-                        responseText: "continue"
+                        responseText: "substitute"
                     }
                 });
             },
             respond: function (code, responseText) {
-                message.send("ResourceRequestedResponse", {
-                    url: url,
-                    response: {
-                        code: code,
-                        responseText: responseText
-                    }
-                });
+                if (mine) {
+                    message.send("ResourceRequestedResponse", {
+                        url: url,
+                        response: {
+                            code: code,
+                            responseText: responseText
+                        }
+                    });
+                }
+                else {
+                    exception.raise(exception.types.InvalidState, "Cannot respond until after substitute has been requested");
+                }
             }
         };
     }

--- a/test/unit/request.js
+++ b/test/unit/request.js
@@ -62,15 +62,15 @@ describe("request", function () {
         });
     });
 
-    describe("continue", function () {
-        it("sends the appropriate message when marking a request as continue", function () {
+    describe("substitute", function () {
+        it("sends the appropriate message when marking a request as substitute", function () {
             var req = request.init("http://www.rim.com");
-            req.continue();
+            req.substitute();
             expect(message.send).toHaveBeenCalledWith("ResourceRequestedResponse", {
                 url: "http://www.rim.com",
                 response: {
                     code: 100,
-                    responseText: "continue"
+                    responseText: "substitute"
                 }
             });
         });
@@ -79,6 +79,7 @@ describe("request", function () {
     describe("respond", function () {
         it("can takeover response to a request", function () {
             var req = request.init("http://www.rim.com");
+            req.substitute();
             req.respond(204, "No Content");
             expect(message.send).toHaveBeenCalledWith("ResourceRequestedResponse", {
                 url: "http://www.rim.com",
@@ -87,6 +88,24 @@ describe("request", function () {
                     responseText: "No Content"
                 }
             });
+        });
+
+        it("throws an exception if substitute has not been requested before responding", function () {
+            var req = request.init("http://www.rim.com");
+            expect(function () {
+                req.respond(204, "No Content");
+            }).toThrow();
+            expect(message.send).not.toHaveBeenCalled();
+        });
+
+        it("throws an exception when a second request has not requested substitute before responding", function () {
+            var req1 = request.init("http://www.rim.com"),
+                req2 = request.init("http://www.blackberry.com");
+
+            req1.substitute();
+            expect(function () {
+                req2.respond(204, "No Content");
+            }).toThrow();
         });
     });
 });  


### PR DESCRIPTION
- Updated request module to use new naming structure. 
- Also enforced the precondition that `request.substitute()` is called before `request.respond()`

Review ? @jasondscott
